### PR TITLE
Fix creation & deletion of symlink to temporary directory

### DIFF
--- a/pkg/hooks/Luks.py
+++ b/pkg/hooks/Luks.py
@@ -15,6 +15,12 @@ class Luks(Hook):
     # the decryption of your / pool (when your /boot is also on /).
     _keyfile_path = "/crypto_keyfile.bin"
 
+    # Should we embed our LUKS header into the initramfs?
+    _use_detached_header = 0
+
+    # Path to the LUKS header you would like to embedded directly into the initramfs.
+    _detached_header_path = "/crypto_header.bin"
+
     # Required Files
     _files = [
         "/sbin/cryptsetup",
@@ -37,3 +43,13 @@ class Luks(Hook):
     @classmethod
     def GetKeyfilePath(cls):
         return cls._keyfile_path
+
+    # Is embedding the LUKS header enabled?
+    @classmethod
+    def IsDetachedHeaderEnabled(cls):
+        return cls._use_detached_header
+
+    # Return the LUKS header path
+    @classmethod
+    def GetDetachedHeaderPath(cls):
+        return cls._detached_header_path

--- a/pkg/libs/Core.py
+++ b/pkg/libs/Core.py
@@ -339,6 +339,12 @@ class Core:
                 Tools.Flag("Embedding our keyfile into the initramfs...")
                 Tools.SafeCopy(Luks.GetKeyfilePath(), var.temp + "/etc", "keyfile")
 
+            # Copy over our detached header if the user activated it
+            # In /etc/default/grub: Modify GRUB_CMDLINE_LINUX to include "enc_options=--header=/etc/header"
+            if Luks.IsDetachedHeaderEnabled():
+                Tools.Flag("Embedding our detached header into the initramfs...")
+                Tools.SafeCopy(Luks.GetDetachedHeaderPath(), var.temp + "/etc", "header")
+
         # Enable RAID in the init if RAID is being used
         if Raid.IsEnabled():
             Tools.ActivateTriggerInInit(var.useRaidLine)

--- a/pkg/libs/Core.py
+++ b/pkg/libs/Core.py
@@ -115,10 +115,16 @@ class Core:
         for dir in var.baselayout:
             call(["mkdir", "-p", dir])
 
-        # Create a symlink to this temporary directory at the home dir.
-        # This will help us debug if anything (since the dirs are randomly
-        # generated...)
-        os.symlink(var.temp, var.tlink)
+        # Ensure graceful symlink creation
+        try:
+            # Create a symlink to this temporary directory at the home dir.
+            # This will help us debug if anything (since the dirs are randomly
+            # generated...)
+            os.symlink(var.temp, var.tlink)
+
+        # When current directory is the temp directory (/tmp)
+        except FileExistsError:
+            Tools.Warn("Skipping temporary link creation: " + var.tlink + " -> " + var.temp)
 
     # Ask the user if they want to use their current kernel, or another one
     @classmethod

--- a/pkg/libs/Core.py
+++ b/pkg/libs/Core.py
@@ -216,6 +216,18 @@ class Core:
     # Create the required symlinks
     @classmethod
     def CreateLinks(cls):
+        # In order to avoid errors in chroot, check for static busybox
+        # Can't assume package dependencies (in ebuild) are fulfilled
+        Tools.Info("Checking for statically linked busybox ...")
+        
+        # Requires 'file' command, but could also use ldd
+        cmd = 'file /bin/busybox'
+        callResult = Tools.Run(cmd)
+        
+        # Re-join output together into single string and check for absence of static
+        if not 'statically linked' in "\n".join(callResult):
+            Tools.Fail("Could not find statically linked busybox!")
+
         Tools.Info("Creating symlinks ...")
 
         # Needs to be from this directory so that the links are relative

--- a/pkg/libs/Tools.py
+++ b/pkg/libs/Tools.py
@@ -115,7 +115,7 @@ class Tools:
         os.chdir(var.home)
 
         # Removes the temporary link created at the start of the app
-        if os.path.exists(var.tlink):
+        if os.path.islink(var.tlink) and os.path.exists(var.tlink):
             os.remove(var.tlink)
 
             if os.path.exists(var.tlink):


### PR DESCRIPTION
Bug fix: the current working directory ('var.home') may be the same as the temporary directory's parent ('/tmp') so when creating the symbolic link ('var.tlink') to the temporary directory ('var.temp') a FileExistsError must be caught to avoid ungraceful termination. In addition, a check confirming that 'var.tlink' is a symlink should be carried out before deletion in order to avoid ungraceful termination, as the 'var.tlink' symlink may not created and actually refer to the 'var.temp' directory.