### PR TITLE
Added enc_targets option to name /dev/mapper targets

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -157,9 +157,12 @@ menuentry "Gentoo - 3.9.9-FB.02" {
 Encrypted Normal with one encrypted drive
 =======================================
 
-** Note: The program will auto mount all your encrypted drives as follows: /dev/mapper/vault_0, /dev/mapper/vault_1,
+** Note: The program will auto mount all your encrypted drives as follows BY DEFAULT: /dev/mapper/vault_0, /dev/mapper/vault_1,
          /dev/mapper/vault_2 ... etc. Thus if you only have one encrypted drive, make sure you name it /dev/mapper/vault_0,
          or use its UUID.
+         
+         OPTIONAL:  You may use enc_targets parameter to specify custom /dev/mapper/<mount_targets> names 
+                    (see LUKS section below)
 
 menuentry "Gentoo - 3.9.9-FB.02" {
     insmod part_gpt
@@ -213,6 +216,21 @@ menuentry "Gentoo - 3.9.9-FB.02" {
     linux /vmlinuz-3.9.9-FB.02 root=tank/gentoo/root enc_drives=/dev/sda3,/dev/sdb3 enc_type=key_gpg enc_key=/farm/animal enc_key_drive=/dev/sdc2 triggers=luks,zfs quiet
     initrd /initrd-3.9.9-FB.02
 }
+
+=======================================
+Encrypted ZFS with an key named "passphrase" in a folder called "lukskeys" on a USB stick drive labeled BOOTKEY, 4 encrypted whole disks and labeled /dev/mapper mountpoints
+=======================================
+
+insmod part_gpt
+insmod fat
+insmod efi_gop
+insmod efi_uga
+
+menuentry "Gentoo - 4.9.16" {
+    linux /@/4.9.16-1/vmlinuz-4.9.16-gentoo root=rpool/ROOT/gentoo enc_drives=/dev/sda,/dev/sdb,/dev/sdc,/dev/sdd enc_targets=csda,csdb,csdc,csdd enc_type=key enc_key=/lukskeys/passphrase enc_key_drive=/dev/disk/by-label/BOOTKEY elevator=noop logo.nologo triggers=luks,zfs
+    initrd /@/4.9.16-1/initrd
+}
+
 
 =======================================
 Encrypted ZFS with a gpg key, 3 encrypted drives for the tank pool, and mixing UUIDs, IDs, Labels, and regular drive naming,
@@ -392,6 +410,10 @@ enc_options - Allows you to pass options to the 'cryptsetup' command
 
 enc_tries - Allows you to set how many times you can retype your passphrase before the initramfs fails to unlock your drives (default is 5)
     example: linux <kernel> enc_tries=10
+    
+enc_targets - What /dev/mapper/TARGET_NAME to use? Comma separated list, same order as enc_drives!
+    example: linux <kernel> enc_drives=/dev/sda1,/dev/sdb1 enc_targets=crypt_sda,crypt_sdb
+
 
 LUKS passphrase/key:
 The easiest way to pass the passphrase is just to wait till the initramfs

--- a/files/init
+++ b/files/init
@@ -870,7 +870,7 @@ NewLine()
 # Shows the welcome message
 WelcomeMessage()
 {
-    Info "Welcome to Bliss! [${_version}] (SL mod)"
+    Info "Welcome to Bliss! [${_version}]"
 }
 
 # Prevent kernel from printing on screen

--- a/files/init
+++ b/files/init
@@ -41,6 +41,7 @@ _embedded_keyfile="/etc/keyfile"
 _cache_file="/etc/zfs/zpool.cache"
 _rootfs_cache_file="${_new_root}${_cache_file}"
 
+
 # Hostnames for initrd and rootfs
 _hostn="initrd"
 _rhostn="rootfs"
@@ -160,6 +161,9 @@ ParseKernelParameters()
             ;;
         enc_drives=*)
             _enc_drives=$(ParseOption "${param}")
+            ;;
+        enc_targets=*)
+            _enc_targets=$(ParseOption "${param}")
             ;;
         enc_type=*)
             _enc_type=$(ParseOption "${param}")
@@ -296,7 +300,7 @@ GetDrivesNeededToDecrypt()
     fi
 
     IFS="," read -a tempDrives <<< "${_enc_drives}"
-
+    
     for i in "${!tempDrives[@]}"; do
         case ${tempDrives[i]} in
             UUID=*)
@@ -539,12 +543,23 @@ DecryptDrives()
     local count=0
     local max="${_enc_tries}"
 
+    if [[ ! -z ${_enc_targets// } ]]; then
+    	IFS="," read -a tempTargets <<< "${_enc_targets}"
+    fi 
+
     for i in "${!_drives[@]}"; do
+    
+    	if [[ -z ${tempTargets[i]// } ]]; then
+    		vaultname=vault_${i}
+    	else
+    		vaultname=${tempTargets[i]}
+    	fi
+    	    
         if [[ ${_enc_type} == "pass" ]]; then
             while [[ ${count} -lt ${max} ]]; do
                 # Putting the _enc_options var in double quotes _will_ cause cryptsetup to fail
                 # and display an "unknown option" message.
-                echo "${_code}" | cryptsetup ${_enc_options} luksOpen "${_drives[i]}" "vault_${i}" && break
+                echo "${_code}" | cryptsetup ${_enc_options} luksOpen "${_drives[i]}" "${vaultname}" && break
 
                 if [[ $? -ne 0 ]]; then
                     count=$((count + 1))
@@ -563,10 +578,12 @@ DecryptDrives()
                 Fail "The keyfile doesn't exist in this path: ${_keyfile}"
             fi
 
-            cryptsetup --key-file "${_keyfile}" ${_enc_options} luksOpen "${_drives[i]}" "vault_${i}"
+            cryptsetup --key-file "${_keyfile}" ${_enc_options} luksOpen "${_drives[i]}" "${vaultname}"
 
             if [[ $? -ne 0 ]]; then
                 Fail "Failed to decrypt ${_drives[i]}!"
+            else
+            	Flag "${_drives[i]} opened -> ${vaultname}"
             fi
         elif [[ ${_enc_type} == "key_gpg" ]]; then
             if [[ ! -e ${_keyfile} ]]; then
@@ -575,7 +592,7 @@ DecryptDrives()
 
             while [[ ${count} -lt ${max} ]]; do
                 echo "${_code}" | gpg --batch --passphrase-fd 0 -q -d "${_keyfile}" 2> /dev/null | \
-                cryptsetup --key-file=- ${_enc_options} luksOpen ${_drives[i]} vault_${i} && break
+                cryptsetup --key-file=- ${_enc_options} luksOpen ${_drives[i]} ${vaultname} && break
 
                 if [[ $? -ne 0 ]]; then
                     count=$((count + 1))
@@ -591,6 +608,8 @@ DecryptDrives()
             done
         fi
     done
+    
+    unset tempTargets
 }
 
 # If "use_raid" is enabled, raid specific code will be ran
@@ -851,7 +870,7 @@ NewLine()
 # Shows the welcome message
 WelcomeMessage()
 {
-    Info "Welcome to Bliss! [${_version}]"
+    Info "Welcome to Bliss! [${_version}] (SL mod)"
 }
 
 # Prevent kernel from printing on screen


### PR DESCRIPTION
Simply for better readability in the running system and for setups which depend on dev labels. While ZFS will find the containers usually no matter how they are named, other filesystems might not.

**USAGE:**
via boot parameter **enc_targets**

**EXAMPLE:**
enc_drives=/dev/sda,/dev/sdb enc_targets=crypt_sda,crypt_sdb

will map to cryptsetup mapper path by name:

dev/sda -> /dev/mapper/crypt_sda
dev/sdb -> /dev/mapper/crypt_sdb

if not specified, default Vault_[i] will be used:

dev/sda -> /dev/mapper/Vault_0
dev/sdb -> /dev/mapper/Vault_1

**NOTES:**
- "enc_targets" was chosen over of "enc_vaults" because of better association with "target" in dmcrypt.conf

- line 586+: additionally, an success message after each opened container was added. I did this because opening many containers (10 tested) takes a long time and there was no response meanwhile from the script