### PR TITLE
Add enc_targets_by_basename parameter.

### DIFF
--- a/files/init
+++ b/files/init
@@ -535,7 +535,7 @@ DecryptDrives()
     for i in "${!_drives[@]}"; do
     
         if [[ -z ${tempTargets[i]// } ]]; then
-            vaultname=vault_${i}
+            vaultname="vault_${i}_$(basename "${_drives[i]}")"
         else
             vaultname=${tempTargets[i]}
         fi


### PR DESCRIPTION
For deriving names from the base raw drive name.  Especially useful with by-id disks.  Before this when I `zpool status` (ZFS on LUKS) I got:

        NAME        STATE     READ WRITE CKSUM
        paranoid    ONLINE       0     0     0
          raidz2-0  ONLINE       0     0     0
            dm-0    ONLINE       0     0     0
            dm-1    ONLINE       0     0     0
            dm-4    ONLINE       0     0     0
            dm-3    ONLINE       0     0     0

And if one of the drives developed a problem, I didn't know which.  After this (and by=/dev/mapper -- and fixing that):

        NAME                                          STATE     READ WRITE CKSUM
        paranoid                                      ONLINE       0     0     0
          raidz2-0                                    ONLINE       0     0     0
            vault_ata-HGST_HUH728080ALE604_XXX-part2  ONLINE       0     0     0
            vault_ata-HGST_HUH728080ALE604_XXX-part2  ONLINE       0     0     0
            vault_ata-HGST_HUH728080ALE604_XXX-part2  ONLINE       0     0     0
            vault_ata-HGST_HUH728080ALE604_XXX-part2  ONLINE       0     0     0

Serial numbers elided.  But I can read them, so I know which ZFS vdev is which physical disk!
