### PR TITLE
Fix ParseByOption.

### DIFF
--- a/files/init
+++ b/files/init
@@ -230,7 +230,7 @@ ParseByOption()
             echo "/dev/disk/by-partlabel"
             ;;
         *)
-            echo "${tempDrive}"
+            echo "${option}"
             ;;
     esac
 


### PR DESCRIPTION
An apparent copypasta mistake broke the "*" case of this function.  I've built and confirmed this -- see #29 .